### PR TITLE
Add Environment Variable to Enable SELinux Metrics in CWA

### DIFF
--- a/amazon_cloudwatch_agent.sh
+++ b/amazon_cloudwatch_agent.sh
@@ -17,4 +17,19 @@ make -f /usr/share/selinux/devel/Makefile amazon_cloudwatch_agent.pp || exit
 /sbin/restorecon -R -v /opt/aws/amazon-cloudwatch-agent || true
 /sbin/restorecon -v /etc/systemd/system/amazon-cloudwatch-agent.service || true
 
-echo "Policy loaded. You may need to restart the CloudWatch agent: systemctl restart amazon-cloudwatch-agent"
+echo "Adding environment variable to systemd service"
+
+# Ensure the directory exists
+mkdir -p /etc/systemd/system/amazon-cloudwatch-agent.service.d
+
+# Create the override file with the Environment variable
+cat <<EOF | tee /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
+[Service]
+Environment="RUN_WITH_SELINUX=True"
+EOF
+
+# Reload systemd and restart the CloudWatch agent
+systemctl daemon-reload
+systemctl restart amazon-cloudwatch-agent
+
+echo "Policy loaded. CloudWatch agent should be restarted with the new environment variable: systemctl restart amazon-cloudwatch-agent"

--- a/amazon_cloudwatch_agent.sh
+++ b/amazon_cloudwatch_agent.sh
@@ -2,9 +2,18 @@
 
 DIRNAME=`dirname $0`
 cd $DIRNAME
-USAGE="$0 [ --update ]"
+USAGE="$0 [ -y | -Y | --yes ]"
+
+# Check for auto-approve flag
+AUTO_APPROVE=false
+if [ "$1" = "-y" ] || [ "$1" = "-Y" ] || [ "$1" = "--yes" ]; then
+    AUTO_APPROVE=true
+fi
+
+# Ensure the script is running as root or with sudo
 if [ `id -u` != 0 ]; then
-    echo 'You must be root to run this script'
+    echo "This script requires root privileges. Please run with sudo:"
+    echo "sudo $0"
     exit 1
 fi
 
@@ -17,4 +26,33 @@ make -f /usr/share/selinux/devel/Makefile amazon_cloudwatch_agent.pp || exit
 /sbin/restorecon -R -v /opt/aws/amazon-cloudwatch-agent || true
 /sbin/restorecon -v /etc/systemd/system/amazon-cloudwatch-agent.service || true
 
-echo "Policy loaded. You may need to restart the CloudWatch agent: systemctl restart amazon-cloudwatch-agent"
+echo "Adding environment variable to systemd service"
+
+# Ensure the directory exists
+sudo mkdir -p /etc/systemd/system/amazon-cloudwatch-agent.service.d
+
+# Create the override file with the Environment variable
+cat <<EOF | sudo tee /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
+[Service]
+Environment="RUN_WITH_SELINUX=True"
+EOF
+
+# Reload systemd
+sudo systemctl daemon-reload
+
+# Check if auto-approve is enabled, otherwise ask the user
+if [ "$AUTO_APPROVE" = true ]; then
+    echo "Auto-approve enabled. Restarting CloudWatch Agent..."
+    sudo systemctl restart amazon-cloudwatch-agent
+    echo "CloudWatch Agent has been restarted."
+else
+    read -p "Would you like to restart the CloudWatch Agent now? (y/N): " confirm
+    if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+        sudo systemctl restart amazon-cloudwatch-agent
+        echo "CloudWatch Agent has been restarted."
+    else
+        echo "CloudWatch Agent was not restarted. Please restart it manually using: sudo systemctl restart amazon-cloudwatch-agent"
+    fi
+fi
+
+echo "Policy loaded. Environment variable applied."

--- a/amazon_cloudwatch_agent.sh
+++ b/amazon_cloudwatch_agent.sh
@@ -19,12 +19,12 @@ fi
 
 echo "Building and Loading Policy"
 set -x
-sudo make -f /usr/share/selinux/devel/Makefile amazon_cloudwatch_agent.pp || exit
-sudo /usr/sbin/semodule -i amazon_cloudwatch_agent.pp
+make -f /usr/share/selinux/devel/Makefile amazon_cloudwatch_agent.pp || exit
+/usr/sbin/semodule -i amazon_cloudwatch_agent.pp
 
 # Fixing the file context on CloudWatch agent files
-sudo /sbin/restorecon -R -v /opt/aws/amazon-cloudwatch-agent || true
-sudo /sbin/restorecon -v /etc/systemd/system/amazon-cloudwatch-agent.service || true
+/sbin/restorecon -R -v /opt/aws/amazon-cloudwatch-agent || true
+/sbin/restorecon -v /etc/systemd/system/amazon-cloudwatch-agent.service || true
 
 echo "Adding environment variable to systemd service"
 

--- a/amazon_cloudwatch_agent.sh
+++ b/amazon_cloudwatch_agent.sh
@@ -54,5 +54,3 @@ else
         echo "CloudWatch Agent was not restarted. Please restart it manually using: sudo systemctl restart amazon-cloudwatch-agent"
     fi
 fi
-
-echo "Policy loaded. Environment variable applied."

--- a/amazon_cloudwatch_agent.sh
+++ b/amazon_cloudwatch_agent.sh
@@ -3,6 +3,7 @@
 DIRNAME=`dirname $0`
 cd $DIRNAME
 USAGE="$0 [ --update ]"
+
 if [ `id -u` != 0 ]; then
     echo 'You must be root to run this script'
     exit 1
@@ -28,8 +29,16 @@ cat <<EOF | tee /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.c
 Environment="RUN_WITH_SELINUX=True"
 EOF
 
-# Reload systemd and restart the CloudWatch agent
-systemctl daemon-reload
-systemctl restart amazon-cloudwatch-agent
+# Reload systemd
+sudo systemctl daemon-reload
 
-echo "Policy loaded. CloudWatch agent should be restarted with the new environment variable: systemctl restart amazon-cloudwatch-agent"
+# Ask the customer if they want to restart the CloudWatch agent
+read -p "Would you like to restart the CloudWatch Agent now? (y/N): " confirm
+if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+    sudo systemctl restart amazon-cloudwatch-agent
+    echo "CloudWatch Agent has been restarted."
+else
+    echo "CloudWatch Agent was not restarted. Please restart it manually using: systemctl restart amazon-cloudwatch-agent"
+fi
+
+echo "Policy loaded. Environment variable applied."

--- a/amazon_cloudwatch_agent.sh
+++ b/amazon_cloudwatch_agent.sh
@@ -2,29 +2,37 @@
 
 DIRNAME=`dirname $0`
 cd $DIRNAME
-USAGE="$0 [ --update ]"
+USAGE="$0 [ -y | -Y | --yes ]"
 
+# Check for auto-approve flag
+AUTO_APPROVE=false
+if [ "$1" = "-y" ] || [ "$1" = "-Y" ] || [ "$1" = "--yes" ]; then
+    AUTO_APPROVE=true
+fi
+
+# Ensure the script is running as root or with sudo
 if [ `id -u` != 0 ]; then
-    echo 'You must be root to run this script'
+    echo "This script requires root privileges. Please run with sudo:"
+    echo "sudo $0"
     exit 1
 fi
 
 echo "Building and Loading Policy"
 set -x
-make -f /usr/share/selinux/devel/Makefile amazon_cloudwatch_agent.pp || exit
-/usr/sbin/semodule -i amazon_cloudwatch_agent.pp
+sudo make -f /usr/share/selinux/devel/Makefile amazon_cloudwatch_agent.pp || exit
+sudo /usr/sbin/semodule -i amazon_cloudwatch_agent.pp
 
 # Fixing the file context on CloudWatch agent files
-/sbin/restorecon -R -v /opt/aws/amazon-cloudwatch-agent || true
-/sbin/restorecon -v /etc/systemd/system/amazon-cloudwatch-agent.service || true
+sudo /sbin/restorecon -R -v /opt/aws/amazon-cloudwatch-agent || true
+sudo /sbin/restorecon -v /etc/systemd/system/amazon-cloudwatch-agent.service || true
 
 echo "Adding environment variable to systemd service"
 
 # Ensure the directory exists
-mkdir -p /etc/systemd/system/amazon-cloudwatch-agent.service.d
+sudo mkdir -p /etc/systemd/system/amazon-cloudwatch-agent.service.d
 
 # Create the override file with the Environment variable
-cat <<EOF | tee /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
+cat <<EOF | sudo tee /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
 [Service]
 Environment="RUN_WITH_SELINUX=True"
 EOF
@@ -32,13 +40,19 @@ EOF
 # Reload systemd
 sudo systemctl daemon-reload
 
-# Ask the customer if they want to restart the CloudWatch agent
-read -p "Would you like to restart the CloudWatch Agent now? (y/N): " confirm
-if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+# Check if auto-approve is enabled, otherwise ask the user
+if [ "$AUTO_APPROVE" = true ]; then
+    echo "Auto-approve enabled. Restarting CloudWatch Agent..."
     sudo systemctl restart amazon-cloudwatch-agent
     echo "CloudWatch Agent has been restarted."
 else
-    echo "CloudWatch Agent was not restarted. Please restart it manually using: systemctl restart amazon-cloudwatch-agent"
+    read -p "Would you like to restart the CloudWatch Agent now? (y/N): " confirm
+    if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+        sudo systemctl restart amazon-cloudwatch-agent
+        echo "CloudWatch Agent has been restarted."
+    else
+        echo "CloudWatch Agent was not restarted. Please restart it manually using: sudo systemctl restart amazon-cloudwatch-agent"
+    fi
 fi
 
 echo "Policy loaded. Environment variable applied."


### PR DESCRIPTION
*Issue #, if available:*
This commit adds env var to override config of the CloudWatch Agent. The agent will use this for its useragent header to create selinux metrics. 


*Description of changes:*
This commit introduces an environment variable to override the CloudWatch Agent's configuration. Specifically, it ensures that if an override configuration directory does not exist, it will be created. Additionally, the environment variable `RUN_WITH_SELINUX=True` is appended to the configuration file.


This change allows the CloudWatch Agent to set the appropriate user agent header for generating SELinux metrics. The relevant implementation can be found here: [aws/amazon-cloudwatch-agent#1602](https://github.com/aws/amazon-cloudwatch-agent/pull/1602).By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Testing
This pr here shows the usage of this env var[aws/amazon-cloudwatch-agent#1602](https://github.com/aws/amazon-cloudwatch-agent/pull/1602)

## Running script
<img width="694" alt="Screenshot 2025-03-18 at 3 23 42 PM" src="https://github.com/user-attachments/assets/00891579-99a1-42b4-8eeb-d9dd975ec50d" />
