### PR TITLE
Adding permissions for Amp and Cloudwatch Logs 

### DIFF
--- a/amazon_cloudwatch_agent.te
+++ b/amazon_cloudwatch_agent.te
@@ -6,8 +6,44 @@ require {
     type proc_t;
     type proc_net_t;
     type sysfs_t;
+    type unconfined_t;
     type fs_t;
     type cgroup_t;
+    type rpcbind_t;
+    type cloud_init_t;
+    type auditd_t;
+    type monopd_port_t;
+    type getty_t;
+    type unconfined_service_t;
+    type amazon_cloudwatch_agent_t;
+    type setfiles_t;
+    type system_dbusd_t;
+    type rpc_pipefs_t;
+    type postfix_pickup_t;
+    type dhcpc_var_run_t;
+    type hugetlbfs_t;
+    type irqbalance_t;
+    type dhcpc_t;
+    type cert_t;
+    type debugfs_t;
+    type pstore_t;
+    type syslogd_t;
+    type udev_t;
+    type systemd_logind_t;
+    type chronyd_t;
+    type tmpfs_t;
+    type gssproxy_t;
+    type lsmd_t;
+    type sshd_t;
+    type crond_t;
+    type apmd_t;
+    type lvm_t;
+    type postfix_qmgr_t;
+    type postfix_master_t;
+    type rngd_t;
+    type nvme_device_t;
+    type device_t;
+    type collectd_port_t;
     type udev_var_run_t;
     type var_log_t;
     type passwd_file_t;
@@ -20,13 +56,14 @@ require {
     type sysctl_net_t;
     type etc_t;
     type devpts_t;
+    type system_cronjob_t;
     type node_t;
     type ephemeral_port_t;
     type tmp_t;
     type user_tmp_t;
     type unreserved_port_t;
     attribute file_type;
-    class file { getattr open read write append create unlink setattr map };
+    class file { getattr open read write append create unlink setattr map ioctl };
     class dir { open read write search getattr add_name remove_name setattr create };
     class lnk_file { read getattr };
     class netlink_route_socket { create bind write read nlmsg_read nlmsg_write getattr };
@@ -39,6 +76,7 @@ require {
     class udp_socket { create setopt connect getattr write read create_socket_perms };
     class filesystem { getattr };
     class blk_file { getattr open read };
+    class dbus send_msg;
 }
 
 type amazon_cloudwatch_agent_t;
@@ -55,9 +93,68 @@ allow amazon_cloudwatch_agent_t self:process { fork setpgid };
 allow amazon_cloudwatch_agent_t self:fifo_file rw_fifo_file_perms;
 allow amazon_cloudwatch_agent_t self:unix_stream_socket create_stream_socket_perms;
 allow amazon_cloudwatch_agent_t self:tcp_socket create_stream_socket_perms;
+allow amazon_cloudwatch_agent_t collectd_port_t:udp_socket name_bind;
 allow amazon_cloudwatch_agent_t self:udp_socket create_socket_perms;
 allow amazon_cloudwatch_agent_t self:capability { net_admin chown dac_override setgid setuid sys_ptrace dac_read_search };
 allow amazon_cloudwatch_agent_t init_t:file { getattr open read };
+
+#Directory and Symbolic link permissions
+allow amazon_cloudwatch_agent_t apmd_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t apmd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t auditd_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t auditd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t cgroup_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t chronyd_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t chronyd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t crond_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t crond_t:lnk_file read;
+allow amazon_cloudwatch_agent_t debugfs_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t device_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t dhcpc_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t dhcpc_t:lnk_file read;
+allow amazon_cloudwatch_agent_t getty_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t getty_t:lnk_file read;
+allow amazon_cloudwatch_agent_t gssproxy_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t gssproxy_t:lnk_file read;
+allow amazon_cloudwatch_agent_t hugetlbfs_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t irqbalance_t:dir { getattr search read};
+allow amazon_cloudwatch_agent_t irqbalance_t:lnk_file read;
+allow amazon_cloudwatch_agent_t kernel_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t kernel_t:lnk_file read;
+allow amazon_cloudwatch_agent_t lsmd_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t lsmd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t lvm_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t lvm_t:lnk_file read;
+allow amazon_cloudwatch_agent_t nvme_device_t:blk_file getattr;
+allow amazon_cloudwatch_agent_t monopd_port_t:tcp_socket name_bind;
+allow amazon_cloudwatch_agent_t postfix_master_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t postfix_master_t:lnk_file read;
+allow amazon_cloudwatch_agent_t postfix_pickup_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t postfix_pickup_t:lnk_file read;
+allow amazon_cloudwatch_agent_t postfix_qmgr_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t postfix_qmgr_t:lnk_file read;
+allow amazon_cloudwatch_agent_t pstore_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t rngd_t:dir { getattr search read};
+allow amazon_cloudwatch_agent_t rngd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t rpc_pipefs_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t rpcbind_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t rpcbind_t:lnk_file read;
+allow amazon_cloudwatch_agent_t sshd_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t sshd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t syslogd_t:dir { getattr search };
+allow amazon_cloudwatch_agent_t syslogd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t system_cronjob_t:dir getattr;
+allow amazon_cloudwatch_agent_t system_dbusd_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t system_dbusd_t:lnk_file read;
+allow amazon_cloudwatch_agent_t systemd_logind_t:dir { getattr search };
+allow amazon_cloudwatch_agent_t systemd_logind_t:lnk_file read;
+allow amazon_cloudwatch_agent_t tmpfs_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t udev_t:dir { getattr search };
+allow amazon_cloudwatch_agent_t udev_t:lnk_file read;
+allow amazon_cloudwatch_agent_t unconfined_service_t:dir { getattr search read };
+allow amazon_cloudwatch_agent_t unconfined_t:dir { read getattr search };
+allow amazon_cloudwatch_agent_t unconfined_t:lnk_file read;
+allow amazon_cloudwatch_agent_t unconfined_service_t:lnk_file read;
 
 # Network permissions
 # * Grants agent
@@ -100,6 +197,7 @@ allow amazon_cloudwatch_agent_t proc_t:file { read getattr open };
 # Grants access to sysfs and cgroup files
 allow amazon_cloudwatch_agent_t sysfs_t:dir { read getattr open search };
 allow amazon_cloudwatch_agent_t sysfs_t:file { read getattr open };
+allow amazon_cloudwatch_agent_t sysfs_t:filesystem getattr;
 allow amazon_cloudwatch_agent_t cgroup_t:dir { read getattr open search };
 allow amazon_cloudwatch_agent_t cgroup_t:file { read getattr open };
 
@@ -114,10 +212,11 @@ allow amazon_cloudwatch_agent_t sysctl_net_t:file { read open getattr };
 
 # Grants access to /dev/pts, /tmp, network files, /etc/passwd, and process-related files
 allow amazon_cloudwatch_agent_t amazon_cloudwatch_agent_exec_t:dir { open read write search getattr add_name remove_name setattr create };
-allow amazon_cloudwatch_agent_t amazon_cloudwatch_agent_exec_t:file { create open read write getattr unlink execute_no_trans append setattr };
+allow amazon_cloudwatch_agent_t amazon_cloudwatch_agent_exec_t:file { create open read write getattr unlink execute_no_trans append setattr ioctl };
 allow amazon_cloudwatch_agent_t devpts_t:dir { read open getattr search };
 allow amazon_cloudwatch_agent_t devpts_t:file { read open getattr };
-allow amazon_cloudwatch_agent_t tmp_t:dir { read open getattr search };
+allow amazon_cloudwatch_agent_t devpts_t:filesystem getattr;
+allow amazon_cloudwatch_agent_t tmp_t:dir { read open getattr search  write remove_name add_name };
 allow amazon_cloudwatch_agent_t tmp_t:file { read open getattr };
 allow amazon_cloudwatch_agent_t proc_net_t:file { read open getattr };
 allow amazon_cloudwatch_agent_t proc_net_t:lnk_file read;
@@ -143,6 +242,49 @@ files_getattr_all_dirs(amazon_cloudwatch_agent_t)
 
 # Allow the agent to get disk information - Allows reading raw disk information
 storage_raw_read_fixed_disk(amazon_cloudwatch_agent_t)
+
+# This is for AL2023 perm which is why it is optional (This will not be applied for AL2 which is expected)
+optional {
+  require {
+        type bpf_t;
+        type cgroup_t;
+        type configfs_t;
+        type debugfs_t;
+        type device_t;
+        type devpts_t;
+        type dosfs_t;
+        type efivarfs_t;
+        type fs_t;
+        type fusefs_t;
+        type hugetlbfs_t;
+        type pstore_t;
+        type rpc_pipefs_t;
+        type tmp_t;
+        type tmpfs_t;
+        type tracefs_t;
+        class filesystem getattr;
+        class dir write;
+    }
+
+    # These rules will be included if the types exist, otherwise they'll be silently ignored
+    allow amazon_cloudwatch_agent_t bpf_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t cgroup_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t configfs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t debugfs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t device_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t devpts_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t dosfs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t efivarfs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t fs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t fusefs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t hugetlbfs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t pstore_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t rpc_pipefs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t tmp_t:dir write;
+    allow amazon_cloudwatch_agent_t tmpfs_t:filesystem getattr;
+    allow amazon_cloudwatch_agent_t tracefs_t:filesystem getattr;
+}
+
 
 # Explicitly denies access to /etc/shadow (password storage file), preventing:
 # -- Reading or modifying user passwords.


### PR DESCRIPTION
*Issue #, if available:*
This pr fixes failing selinux tests. Some permissions needed to be added to the selinux policy in order to fix failing selinux tests:

Passing tests run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14074781711/job/39415989730
*Description of changes:*
Adding amp and cloudwatch logs permissions


## Picture of permissions needed for amp
<img width="906" alt="Screenshot 2025-03-26 at 12 02 53 AM" src="https://github.com/user-attachments/assets/7a38ec06-dff2-4aa6-aeb6-d0fae5d5ec0d" />
In this Amp run logs that show all the permissions that needed:https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14067560097/job/39394012527

## Picture of permissions needed for cloudwatch logs
<img width="941" alt="Screenshot 2025-03-26 at 12 00 57 AM" src="https://github.com/user-attachments/assets/40e8f775-c629-4373-afca-edcad9bab45c" />

Cloudwatch logs test showcasing permissions needed:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14067560097/job/39394014703
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
