### PR TITLE
Add SELinux permissions for journald log collection

### DIFF
--- a/amazon_cloudwatch_agent.te
+++ b/amazon_cloudwatch_agent.te
@@ -30,6 +30,8 @@ require {
     type debugfs_t;
     type pstore_t;
     type syslogd_t;
+    type journalctl_exec_t;
+    type syslogd_var_run_t;
     type udev_t;
     type systemd_logind_t;
     type chronyd_t;
@@ -319,6 +321,14 @@ allow amazon_cloudwatch_agent_t proc_t:filesystem getattr;
 # -- Reading Apache HTTPD configuration fil
 allow amazon_cloudwatch_agent_t kernel_t:system syslog_read;
 allow amazon_cloudwatch_agent_t httpd_config_t:file { getattr open read };
+
+# Journald log collection permissions
+# -- Allows the agent to:
+# -- Execute journalctl binary to read journal entries.
+# -- Read journal log files from /var/log/journal/ and /run/log/journal/.
+allow amazon_cloudwatch_agent_t journalctl_exec_t:file { execute execute_no_trans open read getattr map };
+allow amazon_cloudwatch_agent_t syslogd_var_run_t:dir { open read search getattr };
+allow amazon_cloudwatch_agent_t syslogd_var_run_t:file { open read getattr };
 
 # Allow DNS resolution - Grants permission to perform DNS resolution
 sysnet_dns_name_resolve(amazon_cloudwatch_agent_t)

--- a/amazon_cloudwatch_agent.te
+++ b/amazon_cloudwatch_agent.te
@@ -102,8 +102,9 @@ allow amazon_cloudwatch_agent_t self:tcp_socket create_stream_socket_perms;
 allow amazon_cloudwatch_agent_t mail_port_t:tcp_socket name_connect;
 allow amazon_cloudwatch_agent_t collectd_port_t:udp_socket name_bind;
 allow amazon_cloudwatch_agent_t self:udp_socket create_socket_perms;
-allow amazon_cloudwatch_agent_t self:capability { net_admin chown dac_override setgid setuid sys_ptrace dac_read_search };
+allow amazon_cloudwatch_agent_t self:capability { net_admin chown dac_override setgid setuid sys_ptrace dac_read_search sys_resource };
 allow amazon_cloudwatch_agent_t init_t:file { getattr open read };
+allow amazon_cloudwatch_agent_t init_t:dir { search };
 allow amazon_cloudwatch_agent_t apmd_t:dir { getattr search read open };
 allow amazon_cloudwatch_agent_t apmd_t:file { read open getattr write };
 allow amazon_cloudwatch_agent_t apmd_t:lnk_file { read open getattr write };
@@ -275,7 +276,7 @@ allow amazon_cloudwatch_agent_t fs_t:filesystem getattr;
 # Modify /var/log directories.
 # Create, write, and delete log files.
 allow amazon_cloudwatch_agent_t var_log_t:dir { add_name write remove_name };
-allow amazon_cloudwatch_agent_t var_log_t:file { append open setattr create write unlink };
+allow amazon_cloudwatch_agent_t var_log_t:file { append open setattr create write unlink map };
 
 
 # Allows reading /proc system files

--- a/amazon_cloudwatch_agent.te
+++ b/amazon_cloudwatch_agent.te
@@ -69,7 +69,7 @@ require {
     attribute file_type;
     class sock_file { create rename setattr unlink };
     class file { getattr open read write append create unlink setattr map ioctl search execute execute_no_trans };
-    class dir { open read write search getattr add_name remove_name setattr create };
+    class dir { open read write search getattr add_name remove_name setattr create watch };
     class lnk_file { read getattr open getattr write };
     class netlink_route_socket { create bind write read nlmsg_read nlmsg_write getattr };
     class process { fork setpgid execmem };
@@ -95,7 +95,7 @@ init_daemon_domain(amazon_cloudwatch_agent_t, amazon_cloudwatch_agent_exec_t)
 # -- Read/write access to FIFO files (inter-process communication).
 # -- Create and use TCP/UDP sockets.
 # -- Various system capabilities (setuid(Set User ID), setgid(Set Group ID), sys_ptrace(System Process Trace), etc.).
-allow amazon_cloudwatch_agent_t self:process { fork setpgid execmem };
+allow amazon_cloudwatch_agent_t self:process { fork setpgid execmem setrlimit };
 allow amazon_cloudwatch_agent_t self:fifo_file rw_fifo_file_perms;
 allow amazon_cloudwatch_agent_t self:unix_stream_socket create_stream_socket_perms;
 allow amazon_cloudwatch_agent_t self:tcp_socket create_stream_socket_perms;
@@ -275,7 +275,7 @@ allow amazon_cloudwatch_agent_t fs_t:filesystem getattr;
 
 # Modify /var/log directories.
 # Create, write, and delete log files.
-allow amazon_cloudwatch_agent_t var_log_t:dir { add_name write remove_name };
+allow amazon_cloudwatch_agent_t var_log_t:dir { add_name write remove_name watch };
 allow amazon_cloudwatch_agent_t var_log_t:file { append open setattr create write unlink map };
 
 
@@ -333,7 +333,7 @@ optional {
     require {
         type syslogd_var_run_t;
     }
-    allow amazon_cloudwatch_agent_t syslogd_var_run_t:dir { open read search getattr };
+    allow amazon_cloudwatch_agent_t syslogd_var_run_t:dir { open read search getattr watch };
     allow amazon_cloudwatch_agent_t syslogd_var_run_t:file { open read getattr };
 }
 

--- a/amazon_cloudwatch_agent.te
+++ b/amazon_cloudwatch_agent.te
@@ -31,7 +31,6 @@ require {
     type pstore_t;
     type syslogd_t;
     type journalctl_exec_t;
-    type syslogd_var_run_t;
     type udev_t;
     type systemd_logind_t;
     type chronyd_t;
@@ -327,8 +326,15 @@ allow amazon_cloudwatch_agent_t httpd_config_t:file { getattr open read };
 # -- Execute journalctl binary to read journal entries.
 # -- Read journal log files from /var/log/journal/ and /run/log/journal/.
 allow amazon_cloudwatch_agent_t journalctl_exec_t:file { execute execute_no_trans open read getattr map };
-allow amazon_cloudwatch_agent_t syslogd_var_run_t:dir { open read search getattr };
-allow amazon_cloudwatch_agent_t syslogd_var_run_t:file { open read getattr };
+
+# syslogd_var_run_t exists on AL2 (where rsyslog is present) but not on AL2023
+optional {
+    require {
+        type syslogd_var_run_t;
+    }
+    allow amazon_cloudwatch_agent_t syslogd_var_run_t:dir { open read search getattr };
+    allow amazon_cloudwatch_agent_t syslogd_var_run_t:file { open read getattr };
+}
 
 # Allow DNS resolution - Grants permission to perform DNS resolution
 sysnet_dns_name_resolve(amazon_cloudwatch_agent_t)

--- a/amazon_cloudwatch_agent.te
+++ b/amazon_cloudwatch_agent.te
@@ -1,4 +1,4 @@
-policy_module(amazon_cloudwatch_agent, 1.0.2)
+policy_module(amazon_cloudwatch_agent, 1.1.0)
 
 require {
     type bin_t;


### PR DESCRIPTION
*Issue:*

Update the CloudWatch Agent SELinux policy to allow the agent to collect journald logs on AL2 and AL2023 with SELinux in enforcing mode.

*Description of changes:*
 - journalctl execution - Allows amazon_cloudwatch_agent_t to execute /usr/bin/journalctl (journalctl_exec_t) with execute, execute_no_trans, open, read, getattr, map.
  - sys_resource capability - Required by journalctl to set resource limits when reading journal files.
  - init_t:dir search - Allows journalctl to search /proc/1/ (systemd process directory).
  - var_log_t:file map - Allows journalctl to memory-map journal files in /var/log/journal/.
  - var_log_t:dir watch - Allows journalctl --follow to use inotify on /var/log/journal/ for real-time log following.
  - syslogd_var_run_t (optional block) - Allows access to journal runtime files in /run/log/journal/ on systems where this type exists (AL2 with rsyslog). Includes watch for inotify.
  - setrlimit on process — Required by journalctl for resource limit operations.
  - watch added to class dir - Required for inotify directory watch permissions.

*Testing*
  - All journald tests pass in CI for AL2 and AL2023 with SELinux enforcing
  - Policy compiles on both AL2 and AL2023
 
*Integration Test*
- AL2023_Selinux_journald_logs_test
- AL2_Selinux_journald_logs_test
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/25865272301

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

